### PR TITLE
Fix Dialyzer warning

### DIFF
--- a/src/gen_driver.erl
+++ b/src/gen_driver.erl
@@ -37,7 +37,7 @@
 % library associated with the driver, as well as the opened port.
 -record(state, {
   name :: string(),
-  port :: port()
+  port :: port() | undefined
 }).
 
 %% ----------------------------------------------------------------------------


### PR DESCRIPTION
Previously "rebar3 Dialyzer" produced the following warning (tested with Erlang 26 and 27):

    Line 121 Column 38: Record construction #state{name::atom() |
    maybe_improper_list(binary() | maybe_improper_list(any(),binary() |
    []) | byte(),binary() | []),port::'undefined'} violates the declared
    type of field port::port()

This was because the start_link/2 function created a record where the `port` field was left `undefined`. This commit modified the type specification so that this is allowed.